### PR TITLE
Add SQLite persistence (SQLModel) for activities and participants

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+sqlmodel

--- a/scripts/seed_db.py
+++ b/scripts/seed_db.py
@@ -1,0 +1,52 @@
+from sqlmodel import Session
+from src.db import init_db, engine
+from src.models import Activity, ActivityParticipant
+
+
+def seed():
+    init_db()
+    with Session(engine) as session:
+        # Check if there are any activities already
+        existing = session.exec(Activity.select()).first()
+        if existing:
+            print("DB already seeded")
+            return
+
+        activities = [
+            {
+                "name": "Chess Club",
+                "description": "Learn strategies and compete in chess tournaments",
+                "schedule": "Fridays, 3:30 PM - 5:00 PM",
+                "max_participants": 12,
+                "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
+            },
+            {
+                "name": "Programming Class",
+                "description": "Learn programming fundamentals and build software projects",
+                "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+                "max_participants": 20,
+                "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
+            },
+            {
+                "name": "Gym Class",
+                "description": "Physical education and sports activities",
+                "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+                "max_participants": 30,
+                "participants": ["john@mergington.edu", "olivia@mergington.edu"],
+            },
+        ]
+
+        for a in activities:
+            act = Activity(name=a["name"], description=a["description"], schedule=a["schedule"], max_participants=a["max_participants"])
+            session.add(act)
+            session.commit()
+            session.refresh(act)
+            for email in a["participants"]:
+                p = ActivityParticipant(activity_id=act.id, email=email)
+                session.add(p)
+        session.commit()
+        print("Seeded DB with sample activities")
+
+
+if __name__ == "__main__":
+    seed()

--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,16 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
-import os
+from sqlmodel import select
 from pathlib import Path
+import os
+
+from .db import init_db, get_session
+from .models import Activity, ActivityParticipant
+
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -19,63 +24,11 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+
+@app.on_event("startup")
+def on_startup():
+    # Ensure DB tables exist on startup
+    init_db()
 
 
 @app.get("/")
@@ -85,48 +38,56 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    with get_session() as session:
+        activities = session.exec(select(Activity)).all()
+        result = {}
+        for act in activities:
+            # load participants
+            participants = session.exec(select(ActivityParticipant).where(ActivityParticipant.activity_id == act.id)).all()
+            emails = [p.email for p in participants]
+            result[act.name] = {
+                "description": act.description,
+                "schedule": act.schedule,
+                "max_participants": act.max_participants,
+                "participants": emails,
+            }
+        return result
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_session() as session:
+        activity = session.exec(select(Activity).where(Activity.name == activity_name)).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        current_count = session.exec(select(ActivityParticipant).where(ActivityParticipant.activity_id == activity.id)).count()
+        if activity.max_participants is not None and current_count >= activity.max_participants:
+            raise HTTPException(status_code=409, detail="Activity is full")
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+        already = session.exec(select(ActivityParticipant).where(ActivityParticipant.activity_id == activity.id).where(ActivityParticipant.email == email)).first()
+        if already:
+            raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Add student
-    activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+        participant = ActivityParticipant(activity_id=activity.id, email=email)
+        session.add(participant)
+        session.commit()
+        return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_session() as session:
+        activity = session.exec(select(Activity).where(Activity.name == activity_name)).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        participant = session.exec(select(ActivityParticipant).where(ActivityParticipant.activity_id == activity.id).where(ActivityParticipant.email == email)).first()
+        if not participant:
+            raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+        session.delete(participant)
+        session.commit()
+        return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,17 @@
+from sqlmodel import SQLModel, create_engine, Session
+from typing import Optional
+import os
+
+# Use a local SQLite DB file by default. This keeps setup trivial for dev.
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./activities.db")
+
+engine = create_engine(DATABASE_URL, echo=False)
+
+
+def init_db():
+    """Create database tables."""
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Session:
+    return Session(engine)

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,24 @@
+from sqlmodel import SQLModel, Field, Relationship
+from typing import List, Optional
+from datetime import datetime
+
+
+class ActivityParticipant(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    activity_id: int = Field(foreign_key="activity.id")
+    email: str
+    signed_up_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class Activity(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(index=True)
+    description: Optional[str] = None
+    schedule: Optional[str] = None
+    max_participants: Optional[int] = None
+
+    participants: List[ActivityParticipant] = Relationship(back_populates="activity")
+
+
+# Back-populate relationship on the join table
+ActivityParticipant.activity = Relationship(back_populates="participants")


### PR DESCRIPTION
This change adds a minimal SQLite-backed persistence layer using SQLModel.

Changes:
- Add `src/db.py` (engine + session helpers)
- Add `src/models.py` (Activity, ActivityParticipant models)
- Update `src/app.py` to use DB-backed queries and mutate participants via DB
- Add `scripts/seed_db.py` to create tables and seed sample activities
- Add `sqlmodel` to `requirements.txt`

Why: This provides durable storage and unlocks further features (auth, admin UI, exports, concurrency safety).

Notes:
- Runs with SQLite by default (DATABASE_URL env var can change it)
- I kept the API surface the same; behavior should match prior in-memory responses but now persistent.
- Next: implement auth and max-participants concurrency protections as follow-ups.